### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/luisfernandoOrganization/81696098-8895-4dfc-b0d5-2f7d70970e4b/df9d3c4f-b4e9-4a66-ad4b-d93a5ffa8558/_apis/work/boardbadge/b2fe700c-e542-4220-8644-85b130392449)](https://dev.azure.com/luisfernandoOrganization/81696098-8895-4dfc-b0d5-2f7d70970e4b/_boards/board/t/df9d3c4f-b4e9-4a66-ad4b-d93a5ffa8558/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#24](https://dev.azure.com/luisfernandoOrganization/81696098-8895-4dfc-b0d5-2f7d70970e4b/_workitems/edit/24). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.